### PR TITLE
Add a drop type statement for mpaa_rating

### DIFF
--- a/postgres-sakila-db/postgres-sakila-drop-objects.sql
+++ b/postgres-sakila-db/postgres-sakila-drop-objects.sql
@@ -54,3 +54,6 @@ DROP SEQUENCE staff_staff_id_seq;
 DROP SEQUENCE store_store_id_seq;
 
 DROP DOMAIN year;
+
+-- Drop Type
+DROP TYPE mpaa_rating;


### PR DESCRIPTION
Adds a drop type statement for `mpaa_rating` to avoid `type "mpaa_rating" already exists` error on recreation.

This was required for me as I kept nuking and recreating my database multiple times 🙃 

Feel free to close this PR if you think this is not relevant 🙂 

PS: AFAICT only one other DB [yugabyte](https://github.com/jOOQ/sakila/blob/2df186f3e2332cc16dbadeb9b06b95e6361d7517/yugabytedb-sakila-db/yugabytedb-sakila-drop-objects.sql#L58) currently has this, not sure if other DBs require this. I was only able to check this behavior on PostgreSQL.