### PR TITLE
InnoDB storage engine for all tables (`mysql-sakila-schema.sql`)

### DIFF
--- a/mysql-sakila-db/mysql-sakila-schema.sql
+++ b/mysql-sakila-db/mysql-sakila-schema.sql
@@ -174,7 +174,7 @@ CREATE TABLE film_text (
   description TEXT,
   PRIMARY KEY  (film_id),
   FULLTEXT KEY idx_title_description (title,description)
-)ENGINE=MyISAM DEFAULT CHARSET=utf8;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
 -- Triggers for loading film_text from film


### PR DESCRIPTION
## The issue
When I tried to import the database and execute `mysql-sakila-db/mysql-sakila-insert-data.sql` on a freshly installed MySQL 9.6.0 instance with default settings, I encountered an error:

> ERROR 1785 (HY000) at line 12: Statement violates GTID consistency: Updates to non-transactional tables can only be done in either autocommitted statements or single-statement transactions, and never in the same statement as updates to transactional tables.

## Why this happens?
As I understand it, the issue is that MySQL is running with GTID mode enabled (`enforce_gtid_consistency = ON`), and the Sakila script performs operations that:

 - mix transactional tables (e.g., InnoDB)
 - with non-transactional tables (e.g., MyISAM)

GTID mode forbids certain mixed operations because they cannot be replicated safely.

## The solution
There are several ways to resolve this, but the most straightforward solution, in my opinion, is to change the default engine used for the `film_text` table from `ENGINE=MyISAM` to `ENGINE=InnoDB`.

As far as I can tell, InnoDB is used for all other tables, and there are no mentions of MyISAM in previous PRs. I tested the proposed change locally and encountered no issues during import.

Other possible ways to solve this include:

- `SET GLOBAL enforce_gtid_consistency = OFF;` (not recommended for production)
- Wrapping statements in a transaction, e.g.:
  `SET autocommit=0; START TRANSACTION; ... COMMIT; SET autocommit=1;`